### PR TITLE
Add Classic Wooden Twister Roller Coaster

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -2,7 +2,7 @@ export const name = "invention-manager";
 export const authors = ["Katherine Norton (KatieZeldaKat)"];
 export const license = "MIT";
 
-export const version = "1.1.0";
+export const version = "1.2.0";
 export const type = "remote";
 
 /**

--- a/src/objects/Invention.ts
+++ b/src/objects/Invention.ts
@@ -89,6 +89,7 @@ const rideTypes: { [rideType: number]: string } = {
     99: "Classic Wooden Roller Coaster",
     100: "Classic Stand-up Roller Coaster",
     101: "LSM Launched Roller Coaster",
+    102: "Classic Wooden Twister Roller Coaster",
 };
 
 const categoryOrder: { [category: string]: number } = {


### PR DESCRIPTION
Adds the Classic Wooden Twister Roller Coaster to the list of ride types. The plugin still worked before this change, it's just that the ride type would show up as blank.